### PR TITLE
Removed hint bug patch from Saturday and replaced with actual fix. Al…

### DIFF
--- a/src/edu/ipfw/sumfun/Controller.java
+++ b/src/edu/ipfw/sumfun/Controller.java
@@ -39,6 +39,12 @@ public class Controller implements ActionListener {//start Controller class
 		this.tpp = tpp;
 		this.ttp = ttp;
 		view = new SumFunFrame(model, this, tpp, ttp);
+		int[] rowAndCol=model.getHint();
+		if(rowAndCol[0]==-1 || rowAndCol[1]==-1){
+			view.getHint().setEnabled(false);
+		}else{
+			view.getHint().setEnabled(true);
+		}
 		view.setVisible(GUI_VISIBLE);
 	}//end Constructor method
 
@@ -53,12 +59,24 @@ public class Controller implements ActionListener {//start Controller class
 		//Starts a new UntimedGame
 		if(event.getActionCommand().equals("Untimed")) {
 			startNewUntimedGame();
+			int[] rowAndCol=model.getHint();
+			if(rowAndCol[0]==-1 || rowAndCol[1]==-1){
+				view.getHint().setEnabled(false);
+			}else{
+				view.getHint().setEnabled(true);
+			}
 			return;
 		}
 		
 		//Starts a new TimedGame
 		if(event.getActionCommand().equals("Timed")) {
 			startNewTimedGame();
+			int[] rowAndCol=model.getHint();
+			if(rowAndCol[0]==-1 || rowAndCol[1]==-1){
+				view.getHint().setEnabled(false);
+			}else{
+				view.getHint().setEnabled(true);
+			}
 			return;
 		}
 		
@@ -81,12 +99,8 @@ public class Controller implements ActionListener {//start Controller class
 		//Check for an event that needs to give a hint
 		if (event.getActionCommand().equals(HINT)) {
 			int[] rowAndCol=model.getHint();
-			if(rowAndCol[0]==-1 || rowAndCol[1]==-1){
-				view.getHint().setEnabled(false);
-			}else{
-				hintsUsed++;
-				view.getTileGrid()[rowAndCol[0]][rowAndCol[1]].setBackgroundColor(Color.decode(GREEN_HEX_VALUE));
-			}
+			hintsUsed++;
+			view.getTileGrid()[rowAndCol[0]][rowAndCol[1]].setBackgroundColor(Color.decode(GREEN_HEX_VALUE));
 			view.getHint().setEnabled(false);
 			view.repaint();
 			return;

--- a/src/edu/ipfw/sumfun/SumFunFrame.java
+++ b/src/edu/ipfw/sumfun/SumFunFrame.java
@@ -534,6 +534,7 @@ public class SumFunFrame extends JFrame implements Observer {// start SumFunFram
 		} else {
 			String move = "Moves Remaining: N/A";
 			moveLabel.setText(move);
+			moveLabel.setVisible(false);
 		}
 		
 		//Update time remaining
@@ -545,6 +546,7 @@ public class SumFunFrame extends JFrame implements Observer {// start SumFunFram
 		} else {
 			String time = "Time Remaining: N/A";
 			timeLabel.setText(time);
+			timeLabel.setVisible(false);
 		}
 		
 		//Here we are checking if the game is active or not


### PR DESCRIPTION
…so fixed an issue where the time label would become visible on UntimedGame again after a move is played, and added a matching line to keep the moves from showing up on TimedGame, though they weren't for some reason.